### PR TITLE
Check for hostapd package during the installation

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import cli
 import json
 import socket
 import platform
+import time
 
 class Proto:
 	pass
@@ -298,7 +299,9 @@ def main(args):
 	if not os.path.exists('hotspotd.json'):
 		configure()
 		newconfig=True
-
+	if len(cli.check_sysfile('hostapd'))==0:
+		print "hostapd is not installed on your system.This package will not work without it.To install it, try 'sudo apt-get install hostapd' or http://wireless.kernel.org/en/users/Documentation/hostapd after this installation gets over."
+		time.sleep(2) 
 	dc =json.load(open('hotspotd.json'))
 	wlan = dc['wlan']
 	ppp = dc['inet']


### PR DESCRIPTION
The hostapd package will be checked while installing hotspotd and the user will be warned if hostapd is not installed. It is just to make the installer more user friendly.
