### PR TITLE
Adding support for multiple wireless nics

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ The first time you run hotspotd, it will ask you for configuration values for SS
 	* If the above output includes “mac80211” then it means your wifi card will support the AP mode.	
 
 # Testing status
-This package has been tested on Qualcomm Atheros adapter on the following distros:
 
-* Ubuntu 12.04 LTS
-* Ubuntu 14.04 LTS
+This package has been tested on the Raspberry Pi 3 model B running Ubuntu 16.04 xenial armv7l Linux 4.4.38-v7+
+using USB Netgear A6100 wireless AC Adapter as internet source NIC and onboard wifi as AP.
+
+
 
 In theory, it should work with all other distros too (on machines having wifi adapters supported by hostapd), but you will have to try that out and tell me!
 


### PR DESCRIPTION
I wanted to be able to use this application to connect to one wifi network that requires frequent re-login, and broadcast it using another wifi NIC.  This enables the same script to handle the process of re-login every time I want access from any device.  The code didn't support that and sort of assumed one wireless adapter is the case.  I added support for multiple wifi adapters by disabling network managers management of the access point wireless adapter and then re-enabling overall wifi management by network manager.  The code now only disables wifi on the access point wireless NIC.  Allowing another wireless NIC to be the source of access to the internet.